### PR TITLE
Place dark mode toggle beside Add Sample

### DIFF
--- a/Beer-Lambert Color Vizualizer.html
+++ b/Beer-Lambert Color Vizualizer.html
@@ -33,11 +33,14 @@
       color: #333;
       font-weight: bold;
     }
-    .tabs button.add {
+    .tabs button.add,
+    .tabs button.dark-toggle {
       background: #007acc;
       color: #fff;
-      margin-left: auto;
       border-radius: 4px;
+    }
+    .tabs button.dark-toggle {
+      margin-left: auto;
     }
     .sample {
       display: none;
@@ -114,7 +117,6 @@
   </style>
 </head>
 <body>
-  <button id="darkModeToggle" style="position:fixed;top:10px;right:10px;z-index:1000;">Dark Mode</button>
   <div id="app">
     <div id="tabs" class="tabs">
       <!-- Tabs will be inserted here dynamically -->
@@ -768,18 +770,25 @@
       const activeDiv = document.getElementById('sample-' + id);
       if (activeDiv) activeDiv.classList.add('active');
     }
-    // Initialise: add "Add Sample" button and first sample
+    // Initialise: add control buttons and first sample
     function init() {
       const tabsDiv = document.getElementById('tabs');
+      const darkBtn = document.createElement('button');
+      darkBtn.id = 'darkModeToggle';
+      darkBtn.textContent = 'Dark Mode';
+      darkBtn.className = 'dark-toggle';
+      darkBtn.addEventListener('click', () => {
+        document.body.classList.toggle('dark-mode');
+      });
+      tabsDiv.appendChild(darkBtn);
+
       const addBtn = document.createElement('button');
       addBtn.id = 'addTabBtn';
       addBtn.textContent = '+ Add Sample';
       addBtn.className = 'add';
       addBtn.addEventListener('click', addSample);
       tabsDiv.appendChild(addBtn);
-      document.getElementById('darkModeToggle').addEventListener('click', () => {
-        document.body.classList.toggle('dark-mode');
-      });
+
       // Create first sample
       addSample();
     }

--- a/Beer-Lambert Color Vizualizer.html
+++ b/Beer-Lambert Color Vizualizer.html
@@ -41,6 +41,7 @@
     }
     .tabs button.dark-toggle {
       margin-left: auto;
+      margin-right: 0;
     }
     .sample {
       display: none;
@@ -773,6 +774,14 @@
     // Initialise: add control buttons and first sample
     function init() {
       const tabsDiv = document.getElementById('tabs');
+
+      const addBtn = document.createElement('button');
+      addBtn.id = 'addTabBtn';
+      addBtn.textContent = '+ Add Sample';
+      addBtn.className = 'add';
+      addBtn.addEventListener('click', addSample);
+      tabsDiv.appendChild(addBtn);
+
       const darkBtn = document.createElement('button');
       darkBtn.id = 'darkModeToggle';
       darkBtn.textContent = 'Dark Mode';
@@ -781,13 +790,6 @@
         document.body.classList.toggle('dark-mode');
       });
       tabsDiv.appendChild(darkBtn);
-
-      const addBtn = document.createElement('button');
-      addBtn.id = 'addTabBtn';
-      addBtn.textContent = '+ Add Sample';
-      addBtn.className = 'add';
-      addBtn.addEventListener('click', addSample);
-      tabsDiv.appendChild(addBtn);
 
       // Create first sample
       addSample();


### PR DESCRIPTION
## Summary
- Move dark mode toggle into tab bar and align it with the Add Sample button
- Share Add Sample styling with the Dark Mode toggle via a new `dark-toggle` class

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b9aa23a2a083268ed1c9ab442c9aba