### PR TITLE
feat: add fallback for project saving

### DIFF
--- a/Beer-Lambert Color Vizualizer.html
+++ b/Beer-Lambert Color Vizualizer.html
@@ -783,8 +783,9 @@
 
     // Save current project to standalone HTML
     async function saveProject() {
-      const name = prompt('Enter project name', projectName || '') || projectName || 'project';
-      projectName = name;
+      const name = prompt('Enter project name', projectName || '');
+      if (name === null) return;
+      projectName = name || projectName || 'project';
       updateProjectTitle();
       const state = collectState();
       const json = JSON.stringify(state);

--- a/Beer-Lambert Color Vizualizer.html
+++ b/Beer-Lambert Color Vizualizer.html
@@ -725,6 +725,20 @@
     // Generic download helper
     async function downloadFile(content, suggestedName, mime) {
       const blob = new Blob([content], { type: mime });
+
+      // Fallback that uses a temporary anchor element to trigger a download
+      const anchorFallback = () => {
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = suggestedName;
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        // Revoke the object URL after the click to free memory
+        setTimeout(() => URL.revokeObjectURL(url), 0);
+      };
+
       if (window.showSaveFilePicker) {
         try {
           const handle = await window.showSaveFilePicker({
@@ -735,10 +749,12 @@
           await writable.write(blob);
           await writable.close();
         } catch (err) {
-          console.error('Save cancelled or failed', err);
+          console.error('Save cancelled or failed, falling back to anchor download', err);
+          anchorFallback();
         }
       } else {
-        alert('File saving is not supported in this browser.');
+        // If the File System Access API is unavailable, immediately fall back
+        anchorFallback();
       }
     }
 


### PR DESCRIPTION
## Summary
- ensure project downloads use File System Access API when available
- fall back to anchor-based download when the API fails or is missing so the save dialog appears on first click

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68be9693f5e883269804507b60f7c8d6